### PR TITLE
make it so slider collapses on android and add class for drop shadow

### DIFF
--- a/dist/leaflet-slider.js
+++ b/dist/leaflet-slider.js
@@ -41,20 +41,20 @@ L.Control.Slider = L.Control.extend({
         }
     },
     onAdd: function (map) {
-        this._initLayout();
+        this._initLayout(map);
         this.update(this.options.value+"");
         return this._container;
     },
     _updateValue: function () {
         this.value = this.slider.value;
         if (this.options.showValue){
-    	   this._sliderValue.innerHTML = this.options.getValue(this.value);
+           this._sliderValue.innerHTML = this.options.getValue(this.value);
         }
         this.update(this.value);
     },
     _initLayout: function () {
         var className = 'leaflet-control-slider';
-        this._container = L.DomUtil.create('div', className + ' ' +className + '-' + this.options.orientation);
+        this._container = L.DomUtil.create('div', className + ' leaflet-control-layers ' + className + '-' + this.options.orientation);
         this._sliderLink = L.DomUtil.create('a', className + '-toggle', this._container);
         this._sliderLink.setAttribute("title", this.options.title);
         this._sliderLink.innerHTML = this.options.logo;
@@ -120,6 +120,10 @@ L.Control.Slider = L.Control.extend({
                 L.DomEvent
                     .on(this._sliderLink, 'click', L.DomEvent.stop)
                     .on(this._sliderLink, 'click', this._expand, this);
+                var _this = this;
+                map.on('click', function() {
+                    _this._collapse();
+                });
             } else {
                 L.DomEvent.on(this._sliderLink, 'focus', this._expand, this);
             }


### PR DESCRIPTION
On the desktop the slider appears when you hover over it (mousenter) and it goes away when you move your mouse cursor away from it (mouseleave), however, that doesn't really work on mobile as you don't really hover things on a cellphone. On a cellphone you tap the button for the slider to appear but once you do that there's no way to close the slider. That's one of the two things that this PR addresses. With this PR when you click on the map, itself, on a cellphone, the slider goes away.

I also added a new CSS class to the control button that gives it the same border that the other control buttons that leafletjs has have.